### PR TITLE
prevent keybinds from firing when not focused

### DIFF
--- a/src/Creatures/Creatures.tsx
+++ b/src/Creatures/Creatures.tsx
@@ -3,7 +3,7 @@ import useKeyBind from '@zanchi/use-key-bind'
 import compose from 'compose-function'
 import { matchSorter } from 'match-sorter'
 import { FunctionComponent as FC } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { mapKeys, mapValues, pick } from 'remeda'
 
 import { useBool } from 'src/hooks'
@@ -62,6 +62,8 @@ const Creatures: FC<Props> = ({ onAddToInitiative }) => {
   const [expanded, setExpanded] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const [selected, setSelected] = useState<number | null>(null)
+  const containerRef = useRef<HTMLElement | null>(null)
+  const hasFocus = () => containerRef.current?.contains(document.activeElement)
   useEffect(() => {
     setSelected(null)
   }, [searchTerm])
@@ -102,6 +104,7 @@ const Creatures: FC<Props> = ({ onAddToInitiative }) => {
   useKeyBind(
     ['Enter'],
     () => {
+      if (!hasFocus()) return
       if (filteredCreatures.length > 0) {
         const result = filteredCreatures[0].name
         // we're hitting enter from the input
@@ -117,8 +120,22 @@ const Creatures: FC<Props> = ({ onAddToInitiative }) => {
     []
   )
 
-  useKeyBind(['ArrowDown'], selectNext, [setSelected])
-  useKeyBind(['ArrowUp'], selectPrev, [setSelected])
+  useKeyBind(
+    ['ArrowDown'],
+    () => {
+      if (!hasFocus()) return
+      selectNext()
+    },
+    [setSelected]
+  )
+  useKeyBind(
+    ['ArrowUp'],
+    () => {
+      if (!hasFocus()) return
+      selectPrev()
+    },
+    [setSelected]
+  )
 
   const deselect = () => setExpanded('')
   const select = (name: string) => () => setExpanded(name)
@@ -161,7 +178,7 @@ const Creatures: FC<Props> = ({ onAddToInitiative }) => {
   )
 
   return (
-    <section class={styles.container}>
+    <section class={styles.container} ref={containerRef}>
       <SearchHeader
         onAdd={toggleCreating}
         onInput={compose(setSearchTerm, getInputVal)}

--- a/src/Initiative/Initiative.tsx
+++ b/src/Initiative/Initiative.tsx
@@ -62,6 +62,9 @@ const Initiative: FC<Props> = ({ rows, rowActions }) => {
       set: setSelections,
     },
   ] = useSelections()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const hasFocus = () =>
+    containerRef.current?.contains(document.activeElement) ?? false
   const [lastSelectedRow, lastSelectedColumn] = last(selections) ?? [NaN, NaN]
 
   // these three `const`s are to support the floating input.
@@ -113,6 +116,7 @@ const Initiative: FC<Props> = ({ rows, rowActions }) => {
   useKeyBind(
     ['Enter', 'ArrowDown'],
     () => {
+      if (!hasFocus()) return
       if (empty(selections)) return
 
       // if `inputValue` only contains numbers we want to store
@@ -280,7 +284,7 @@ const Initiative: FC<Props> = ({ rows, rowActions }) => {
 
   return (
     <FloatingInput.Provider value={input}>
-      <div class={styles.initiative}>
+      <div class={styles.initiative} ref={containerRef}>
         <ol class={styles.rows} ref={sizeRef as Ref<HTMLOListElement>}>
           <Header onSort={sortRows} />
           {rows.map(formatRow(selections, inputValue)).map((r, i) => (


### PR DESCRIPTION
previously, when hitting Enter or Up/Down arrow keys,
it would fire the keybinds for both Initiative
and Creatures, irrespective of focus.
this commit fixes that

resolves #16 